### PR TITLE
Make "Qiskit" and "IBM Quantum" into links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,9 @@
 # Quantum Prototypes
 
-_Quantum Prototypes_ are Qiskit-compatible software packages based on quantum algorithms and applications developed at IBM Quantum. They are made available to you during the development phase to give you early access to cutting-edge research.
+_Quantum Prototypes_ are [Qiskit]-compatible software packages based on quantum algorithms and applications developed at [IBM Quantum]. They are made available to you during the development phase to give you early access to cutting-edge research.
+
+[Qiskit]: https://github.com/Qiskit
+[IBM Quantum]: https://www.ibm.com/quantum-computing/
 
 Quantum prototypes offer the opportunity to interact with the codebase as a researcher or developer and engage with other users. If you would like to share your feedback, you can
 


### PR DESCRIPTION
I've chosen to link to the Qiskit organization on GitHub, as I think it makes sense to keep people within the GitHub interface being that they are there already.  If they'd rather visit qiskit.org, it's then just a single click away.